### PR TITLE
Pack metapackage with Discord.Net.Core version

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -91,16 +91,6 @@ jobs:
           if: startsWith(github.ref, 'refs/tags/')
           run: echo "IsTagBuild=true" >> $GITHUB_ENV
           
-        - name: Generate Beta Suffix
-          if: env.IsTagBuild == 'true' && contains(github.ref_name, '-')
-          env: 
-            REF_NAME: ${{ github.ref_name }}
-          run: echo "Suffix=-${REF_NAME##*-}" >> $GITHUB_ENV
-
-        - name: Generate Suffix
-          if: env.IsTagBuild != 'true'
-          run: echo "Suffix=-nightly.$(date +'%Y%m%d').${{ github.run_number }}" >> $GITHUB_ENV
-          
         - name: setup NuGet
           uses: nuget/setup-nuget@v2
           with:
@@ -113,7 +103,27 @@ jobs:
             path: ${{ env.ArtifactStagingDirectory }}
         
         - name: Pack Metapackage
-          run: nuget pack "src/Discord.Net/Discord.Net.nuspec" -OutputDirectory ${{ env.ArtifactStagingDirectory }} -NonInteractive -p "suffix=${{ env.Suffix }}"
+          run: |
+            shopt -s nullglob
+
+            core_packages=()
+            for package in "${{ env.ArtifactStagingDirectory }}"/Discord.Net.Core.[0-9]*.nupkg; do
+              [[ "$package" == *.symbols.nupkg ]] && continue
+              core_packages+=("$package")
+            done
+
+            if [ "${#core_packages[@]}" -ne 1 ]; then
+              echo "Expected exactly one Discord.Net.Core package, found ${#core_packages[@]}"
+              printf '  %s\n' "${core_packages[@]}"
+              exit 1
+            fi
+
+            version=$(basename "${core_packages[0]}")
+            version="${version#Discord.Net.Core.}"
+            version="${version%.nupkg}"
+
+            echo "Packing metapackage version $version"
+            nuget pack "src/Discord.Net/Discord.Net.nuspec" -OutputDirectory "${{ env.ArtifactStagingDirectory }}" -NonInteractive -Properties "version=$version"
 
         - name: Set API Keys
           run: |

--- a/azure/deploy.yml
+++ b/azure/deploy.yml
@@ -10,22 +10,20 @@ steps:
     dotnet pack "src\Discord.Net.Interactions\Discord.Net.Interactions.csproj" --no-restore --no-build -v minimal -c $(buildConfiguration) -o "$(Build.ArtifactStagingDirectory)" /p:BuildNumber=$(buildNumber) /p:IsTagBuild=$(buildTag)
   displayName: Pack projects
 
-- task: NuGetCommand@2
-  displayName: Pack metapackage (release mode)
-  condition: eq(variables['buildTag'], True)
-  inputs:
-    command: 'pack'
-    packagesToPack: 'src/Discord.Net/Discord.Net.nuspec'
-    versioningScheme: 'off'  
+- pwsh: |
+    $package = Get-ChildItem $(Build.ArtifactStagingDirectory)/Discord.Net.Core*.nupkg
+    $version = $package.Name.Replace("Discord.Net.Core.", "").Replace(".nupkg", "")
+
+    Write-Output "##vso[task.setvariable variable=packedVersion;]$version"
+  displayName: Retrieve packed version
 
 - task: NuGetCommand@2
   displayName: Pack metapackage
-  condition: eq(variables['buildTag'], False)
   inputs:
     command: 'pack'
     packagesToPack: 'src/Discord.Net/Discord.Net.nuspec'
     versioningScheme: 'off'
-    buildProperties: 'suffix=-$(buildNumber)'
+    buildProperties: 'version=$(packedVersion)'
 
 - task: NuGetCommand@2
   displayName: Push to NuGet

--- a/src/Discord.Net/Discord.Net.nuspec
+++ b/src/Discord.Net/Discord.Net.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Discord.Net</id>
-    <version>3.1.0$suffix$</version>
+    <version>$version$</version>
     <title>Discord.Net</title>
     <authors>Discord.Net Contributors</authors>
     <owners>foxbot</owners>
@@ -14,44 +14,44 @@
     <iconUrl>https://github.com/RogueException/Discord.Net/raw/dev/docs/marketing/logo/PackageLogo.png</iconUrl>
     <dependencies>
         <group targetFramework="net6.0">
-            <dependency id="Discord.Net.Core" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.Rest" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.WebSocket" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.Commands" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.Webhook" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.Interactions" version="3.1.0$suffix$" />
+            <dependency id="Discord.Net.Core" version="$version$" />
+            <dependency id="Discord.Net.Rest" version="$version$" />
+            <dependency id="Discord.Net.WebSocket" version="$version$" />
+            <dependency id="Discord.Net.Commands" version="$version$" />
+            <dependency id="Discord.Net.Webhook" version="$version$" />
+            <dependency id="Discord.Net.Interactions" version="$version$" />
         </group>
         <group targetFramework="net5.0">
-            <dependency id="Discord.Net.Core" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.Rest" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.WebSocket" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.Commands" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.Webhook" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.Interactions" version="3.1.0$suffix$" />
+            <dependency id="Discord.Net.Core" version="$version$" />
+            <dependency id="Discord.Net.Rest" version="$version$" />
+            <dependency id="Discord.Net.WebSocket" version="$version$" />
+            <dependency id="Discord.Net.Commands" version="$version$" />
+            <dependency id="Discord.Net.Webhook" version="$version$" />
+            <dependency id="Discord.Net.Interactions" version="$version$" />
         </group>
         <group targetFramework="net461">
-            <dependency id="Discord.Net.Core" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.Rest" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.WebSocket" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.Commands" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.Webhook" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.Interactions" version="3.1.0$suffix$" />
+            <dependency id="Discord.Net.Core" version="$version$" />
+            <dependency id="Discord.Net.Rest" version="$version$" />
+            <dependency id="Discord.Net.WebSocket" version="$version$" />
+            <dependency id="Discord.Net.Commands" version="$version$" />
+            <dependency id="Discord.Net.Webhook" version="$version$" />
+            <dependency id="Discord.Net.Interactions" version="$version$" />
         </group>
         <group targetFramework="netstandard2.0">
-            <dependency id="Discord.Net.Core" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.Rest" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.WebSocket" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.Commands" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.Webhook" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.Interactions" version="3.1.0$suffix$" />
+            <dependency id="Discord.Net.Core" version="$version$" />
+            <dependency id="Discord.Net.Rest" version="$version$" />
+            <dependency id="Discord.Net.WebSocket" version="$version$" />
+            <dependency id="Discord.Net.Commands" version="$version$" />
+            <dependency id="Discord.Net.Webhook" version="$version$" />
+            <dependency id="Discord.Net.Interactions" version="$version$" />
         </group>
         <group targetFramework="netstandard2.1">
-            <dependency id="Discord.Net.Core" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.Rest" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.WebSocket" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.Commands" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.Webhook" version="3.1.0$suffix$" />
-            <dependency id="Discord.Net.Interactions" version="3.1.0$suffix$" />
+            <dependency id="Discord.Net.Core" version="$version$" />
+            <dependency id="Discord.Net.Rest" version="$version$" />
+            <dependency id="Discord.Net.WebSocket" version="$version$" />
+            <dependency id="Discord.Net.Commands" version="$version$" />
+            <dependency id="Discord.Net.Webhook" version="$version$" />
+            <dependency id="Discord.Net.Interactions" version="$version$" />
         </group>
     </dependencies>
   </metadata>

--- a/src/Discord.Net/Discord.Net.nuspec
+++ b/src/Discord.Net/Discord.Net.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Discord.Net</id>
-    <version>3.20.1$suffix$</version>
+    <version>$version$</version>
     <title>Discord.Net</title>
     <authors>Discord.Net Contributors</authors>
     <owners>foxbot</owners>
@@ -15,28 +15,28 @@
     <readme>NUGET_README.md</readme>
     <dependencies>
         <group targetFramework="net10.0">
-          <dependency id="Discord.Net.Core" version="3.20.1$suffix$" />
-          <dependency id="Discord.Net.Rest" version="3.20.1$suffix$" />
-          <dependency id="Discord.Net.WebSocket" version="3.20.1$suffix$" />
-          <dependency id="Discord.Net.Commands" version="3.20.1$suffix$" />
-          <dependency id="Discord.Net.Webhook" version="3.20.1$suffix$" />
-          <dependency id="Discord.Net.Interactions" version="3.20.1$suffix$" />
+          <dependency id="Discord.Net.Core" version="$version$" />
+          <dependency id="Discord.Net.Rest" version="$version$" />
+          <dependency id="Discord.Net.WebSocket" version="$version$" />
+          <dependency id="Discord.Net.Commands" version="$version$" />
+          <dependency id="Discord.Net.Webhook" version="$version$" />
+          <dependency id="Discord.Net.Interactions" version="$version$" />
         </group>
         <group targetFramework="net9.0">
-            <dependency id="Discord.Net.Core" version="3.20.1$suffix$" />
-            <dependency id="Discord.Net.Rest" version="3.20.1$suffix$" />
-            <dependency id="Discord.Net.WebSocket" version="3.20.1$suffix$" />
-            <dependency id="Discord.Net.Commands" version="3.20.1$suffix$" />
-            <dependency id="Discord.Net.Webhook" version="3.20.1$suffix$" />
-            <dependency id="Discord.Net.Interactions" version="3.20.1$suffix$" />
+            <dependency id="Discord.Net.Core" version="$version$" />
+            <dependency id="Discord.Net.Rest" version="$version$" />
+            <dependency id="Discord.Net.WebSocket" version="$version$" />
+            <dependency id="Discord.Net.Commands" version="$version$" />
+            <dependency id="Discord.Net.Webhook" version="$version$" />
+            <dependency id="Discord.Net.Interactions" version="$version$" />
         </group>
         <group targetFramework="net8.0">
-            <dependency id="Discord.Net.Core" version="3.20.1$suffix$" />
-            <dependency id="Discord.Net.Rest" version="3.20.1$suffix$" />
-            <dependency id="Discord.Net.WebSocket" version="3.20.1$suffix$" />
-            <dependency id="Discord.Net.Commands" version="3.20.1$suffix$" />
-            <dependency id="Discord.Net.Webhook" version="3.20.1$suffix$" />
-            <dependency id="Discord.Net.Interactions" version="3.20.1$suffix$" />
+            <dependency id="Discord.Net.Core" version="$version$" />
+            <dependency id="Discord.Net.Rest" version="$version$" />
+            <dependency id="Discord.Net.WebSocket" version="$version$" />
+            <dependency id="Discord.Net.Commands" version="$version$" />
+            <dependency id="Discord.Net.Webhook" version="$version$" />
+            <dependency id="Discord.Net.Interactions" version="$version$" />
         </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
To avoid any mismatch between both versions and duplication in the code,
the .nuspec file is simplified. The build process now ensures the
version is set to the exact version Discord.Net.Core is packed with.