### PR TITLE
MessageComponent: Add better json type exception

### DIFF
--- a/src/Discord.Net.Rest/Net/Converters/MessageComponentConverter.cs
+++ b/src/Discord.Net.Rest/Net/Converters/MessageComponentConverter.cs
@@ -1,7 +1,6 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
-using System.ComponentModel;
 
 namespace Discord.Net.Converters
 {
@@ -21,8 +20,10 @@ namespace Discord.Net.Converters
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             var jsonObject = JObject.Load(reader);
-            var messageComponent = default(IMessageComponent);
-            switch ((ComponentType)jsonObject["type"].Value<int>())
+            var typeProperty = jsonObject["type"].Value<int>();
+
+            IMessageComponent messageComponent;
+            switch ((ComponentType)typeProperty)
             {
                 case ComponentType.ActionRow:
                     messageComponent = new API.ActionRowComponent();
@@ -61,6 +62,8 @@ namespace Discord.Net.Converters
                 case ComponentType.Container:
                     messageComponent = new API.ContainerComponent();
                     break;
+                default:
+                    throw new JsonSerializationException($"Unknown component type value '{typeProperty}' while deserializing message component");
             }
             serializer.Populate(jsonObject.CreateReader(), messageComponent);
             return messageComponent;


### PR DESCRIPTION
### Description
Currently in MessageComponentConverter, the error on unknown type is System.ArgumentNullException: Value cannot be null. (Parameter 'target')

This is because PopulateObject() doesn't allow a null target, but we don't have a default case on the switch statement.

### Changes
Add a default case with a better exception when this situation happens.