### PR TITLE
fix for #3269: dave rebuild input streams on every protocol transition

### DIFF
--- a/src/Discord.Net.WebSocket/Audio/DaveSessionManager.cs
+++ b/src/Discord.Net.WebSocket/Audio/DaveSessionManager.cs
@@ -245,17 +245,13 @@ internal sealed class DaveSessionManager : IDisposable
 
         UpdateEncryptorRatchet(protocolVersion);
 
+        await _client.RebuildInputStreamsForDaveAsync();
+
         if (transitionId is Dave.InitTransitionId)
-        {
-            // Streams created before DAVE was initialized lack the DaveDecryptStream layer.
-            // Rebuild them now that keys are ready.
-            await _client.RebuildInputStreamsForDaveAsync();
-        }
-        else
-        {
-            _preparedTransitions[transitionId] = protocolVersion;
-            await SendDaveProtocolReadyForTransitionAsync(transitionId);
-        }
+            return;
+
+        _preparedTransitions[transitionId] = protocolVersion;
+        await SendDaveProtocolReadyForTransitionAsync(transitionId);
     }
 
     public async Task HandleDaveProtocolInitAsync(ushort protocolVersion)


### PR DESCRIPTION
Fixes [#3269](https://github.com/discord-net/Discord.Net/issues/3269).

Description
the old code only rebuilt streams on InitTransitionId, so any user who joined after the initial setup never got a decrypt stream