### PR TITLE
fix for #3269

### DIFF
--- a/src/Discord.Net.WebSocket/Audio/DaveSessionManager.cs
+++ b/src/Discord.Net.WebSocket/Audio/DaveSessionManager.cs
@@ -144,7 +144,7 @@ internal sealed class DaveSessionManager : IDisposable
         if (welcomeResult.IsNull)
         {
             await SendMLSInvalidCommitWelcomeAsync(transitionId);
-            await HandleDaveProtocolInitAsync(transitionId);
+            await HandleDaveProtocolInitAsync(_session.ProtocolVersion);
         }
         else
         {
@@ -191,7 +191,7 @@ internal sealed class DaveSessionManager : IDisposable
             using var keyPackage = _session.GetMarshalledKeyPackage();
             await SendMLSKeyPackageAsync(keyPackage.ToMemory());
 
-            await HandleDaveProtocolInitAsync(transitionId);
+            await HandleDaveProtocolInitAsync(_session.ProtocolVersion);
 
             return;
         }
@@ -218,7 +218,7 @@ internal sealed class DaveSessionManager : IDisposable
             using var keyPackage = _session.GetMarshalledKeyPackage();
             await SendMLSKeyPackageAsync(keyPackage.ToMemory());
 
-            await HandleDaveProtocolInitAsync(transitionId);
+            await HandleDaveProtocolInitAsync(_session.ProtocolVersion);
         }
         else
         {
@@ -245,10 +245,17 @@ internal sealed class DaveSessionManager : IDisposable
 
         UpdateEncryptorRatchet(protocolVersion);
 
-        await _client.RebuildInputStreamsForDaveAsync();
+        if (protocolVersion > Dave.DisabledProtocolVersion)
+        {
+            // Streams created before DAVE was initialized lack the DaveDecryptStream layer.
+            // Rebuild them now that keys are ready.
+            await _client.RebuildInputStreamsForDaveAsync();
+        }
 
         if (transitionId is Dave.InitTransitionId)
+        {
             return;
+        }
 
         _preparedTransitions[transitionId] = protocolVersion;
         await SendDaveProtocolReadyForTransitionAsync(transitionId);

--- a/src/Discord.Net.WebSocket/Audio/DaveSessionManager.cs
+++ b/src/Discord.Net.WebSocket/Audio/DaveSessionManager.cs
@@ -245,17 +245,13 @@ internal sealed class DaveSessionManager : IDisposable
 
         UpdateEncryptorRatchet(protocolVersion);
 
+        await _client.RebuildInputStreamsForDaveAsync();
+
         if (transitionId is Dave.InitTransitionId)
-        {
-            // Streams created before DAVE was initialized lack the DaveDecryptStream layer.
-            // Rebuild them now that keys are ready.
-            await _client.RebuildInputStreamsForDaveAsync();
-        }
-        else
-        {
-            _preparedTransitions[transitionId] = protocolVersion;
-            await SendDaveProtocolReadyForTransitionAsync(transitionId);
-        }
+            return;
+
+        _preparedTransitions[transitionId] = protocolVersion;
+        await SendDaveProtocolReadyForTransitionAsync(transitionId);
     }
 
     public async Task HandleDaveProtocolInitAsync(ushort protocolVersion)

--- a/src/Discord.Net.WebSocket/Audio/DaveSessionManager.cs
+++ b/src/Discord.Net.WebSocket/Audio/DaveSessionManager.cs
@@ -188,9 +188,6 @@ internal sealed class DaveSessionManager : IDisposable
             );
 
             await SendMLSInvalidCommitWelcomeAsync(transitionId);
-            using var keyPackage = _session.GetMarshalledKeyPackage();
-            await SendMLSKeyPackageAsync(keyPackage.ToMemory());
-
             await HandleDaveProtocolInitAsync(_session.ProtocolVersion);
 
             return;
@@ -215,9 +212,6 @@ internal sealed class DaveSessionManager : IDisposable
             );
 
             await SendMLSInvalidCommitWelcomeAsync(transitionId);
-            using var keyPackage = _session.GetMarshalledKeyPackage();
-            await SendMLSKeyPackageAsync(keyPackage.ToMemory());
-
             await HandleDaveProtocolInitAsync(_session.ProtocolVersion);
         }
         else


### PR DESCRIPTION
Fixes [#3269](https://github.com/discord-net/Discord.Net/issues/3269).

fix 1:
OnMLSWelcomeAsync and OnDaveMLSAnnounceCommitTransactionAsync Wrong argument passed to HandleDaveProtocolInitAsync

fix 2:
PrepareProtocolTransitionAsync: Wrong condition for rebuilding input streams