### PR TITLE
Fix ModifyOriginalResponseAsync rejecting null content with attachments

### DIFF
--- a/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
@@ -406,8 +406,9 @@ namespace Discord.Rest
             bool hasText = args.Content.IsSpecified ? !string.IsNullOrEmpty(args.Content.Value) : !string.IsNullOrEmpty(message.Content);
             bool hasEmbeds = embed.IsSpecified && embed.Value != null || embeds.IsSpecified && embeds.Value?.Length > 0 || message.Embeds.Any();
             bool hasComponents = args.Components.IsSpecified && args.Components.Value != null;
+            bool hasAttachments = args.Attachments.IsSpecified;
 
-            if (!hasComponents && !hasText && !hasEmbeds)
+            if (!hasComponents && !hasText && !hasEmbeds && !hasAttachments)
                 Preconditions.NotNullOrEmpty(args.Content.IsSpecified ? args.Content.Value : string.Empty, nameof(args.Content));
 
             var apiEmbeds = embed.IsSpecified || embeds.IsSpecified ? new List<API.Embed>() : null;
@@ -453,8 +454,9 @@ namespace Discord.Rest
             bool hasText = !string.IsNullOrEmpty(args.Content.GetValueOrDefault());
             bool hasEmbeds = embed.IsSpecified && embed.Value != null || embeds.IsSpecified && embeds.Value?.Length > 0;
             bool hasComponents = args.Components.IsSpecified && args.Components.Value != null;
+            bool hasAttachments = args.Attachments.IsSpecified;
 
-            if (!hasComponents && !hasText && !hasEmbeds)
+            if (!hasComponents && !hasText && !hasEmbeds && !hasAttachments)
                 Preconditions.NotNullOrEmpty(args.Content.IsSpecified ? args.Content.Value : string.Empty, nameof(args.Content));
 
             var apiEmbeds = embed.IsSpecified || embeds.IsSpecified ? new List<API.Embed>() : null;


### PR DESCRIPTION
### Description
Allows setting `Content = null` in `ModifyOriginalResponseAsync` when `Attachments` are provided. Previously the `Preconditions.NotNullOrEmpty` check would throw even when the user intended to send only attachments without text.

### Changes
- Added `hasAttachments` check in `ModifyInteractionResponseAsync`
- Added `hasAttachments` check in `ModifyFollowupMessageAsync`

### Related Issues
- fixes #3260