### PR TITLE
Add attachment flags and fix container spoiler state

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/Builders/ContainerBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/Builders/ContainerBuilder.cs
@@ -70,7 +70,7 @@ public class ContainerBuilder : IMessageComponentBuilder, IStaticComponentContai
     {
         Components = components?.ToList();
         AccentColor = accentColor;
-        IsSpoiler = IsSpoiler;
+        IsSpoiler = isSpoiler;
         Id = id;
     }
     

--- a/src/Discord.Net.Core/Entities/Messages/AttachmentFlags.cs
+++ b/src/Discord.Net.Core/Entities/Messages/AttachmentFlags.cs
@@ -23,5 +23,16 @@ public enum AttachmentFlags
     /// <summary>
     ///     Indicates that this attachment has been edited using the remix feature on mobile.
     /// </summary>
+    [Obsolete("Discord's remix feature is deprecated.")]
     IsRemix = 1 << 2,
+
+    /// <summary>
+    ///     Hides the attachment behind a spoiler warning.
+    /// </summary>
+    IsSpoiler = 1 << 3,
+
+    /// <summary>
+    ///     Indicates that the attachment contains animated content.
+    /// </summary>
+    IsAnimated = 1 << 5,
 }

--- a/src/Discord.Net.Core/Extensions/AttachmentExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/AttachmentExtensions.cs
@@ -10,6 +10,6 @@ namespace Discord
         ///     Gets whether the message's attachments are spoilers or not.
         /// </summary>
         public static bool IsSpoiler(this IAttachment attachment)
-            => attachment.Filename.StartsWith(SpoilerPrefix);
+            => attachment.Filename.StartsWith(SpoilerPrefix) || attachment.Flags.HasFlag(AttachmentFlags.IsSpoiler);
     }
 }


### PR DESCRIPTION
### Description

Adds the attachment flags currently documented by Discord and fixes spoiler handling in `ContainerBuilder`.

### Changes

- Add `IsSpoiler` and `IsAnimated` to `AttachmentFlags`
- Mark the deprecated `IsRemix` flag as obsolete
- Update `AttachmentExtensions.IsSpoiler()` to recognize Discord’s spoiler flag
- Fix `ContainerBuilder` to correctly apply the `isSpoiler` parameter