### PR TITLE
Give some extra info when no selectmenu options are given

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/Builders/SelectMenuBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/Builders/SelectMenuBuilder.cs
@@ -438,6 +438,12 @@ public class SelectMenuBuilder : IInteractableComponentBuilder
     {
         var options = Options?.Select(x => x.Build()).ToList();
 
+        if (options == null)
+            throw new ArgumentNullException(nameof(Options), "Options must have a value.");
+
+        if (options.Count is 0 or > MaxOptionCount)
+            throw new ArgumentOutOfRangeException(nameof(Options), $"Number of select menu options must be in range [1, {MaxOptionCount}]");
+
         return new SelectMenuComponent(CustomId, options, Placeholder, MinValues, MaxValues, IsRequired, IsDisabled, Type, Id, ChannelTypes, DefaultValues);
     }
 

--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/Builders/SelectMenuBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/Builders/SelectMenuBuilder.cs
@@ -438,13 +438,17 @@ public class SelectMenuBuilder : IInteractableComponentBuilder
     {
         var options = Options?.Select(x => x.Build()).ToList();
 
-        if (options == null)
-            throw new ArgumentNullException(nameof(Options), "Options must have a value.");
+        if (Type == ComponentType.SelectMenu)
+        {
+            if (options is null)
+                throw new ArgumentNullException(nameof(Options), "Options must have a value.");
 
-        if (options.Count is 0 or > MaxOptionCount)
-            throw new ArgumentOutOfRangeException(nameof(Options), $"Number of select menu options must be in range [1, {MaxOptionCount}]");
+            Preconditions.AtLeast(options.Count, 1, nameof(Options));
+            Preconditions.AtMost(options.Count, MaxOptionCount, nameof(Options));
+        }
 
-        return new SelectMenuComponent(CustomId, options, Placeholder, MinValues, MaxValues, IsRequired, IsDisabled, Type, Id, ChannelTypes, DefaultValues);
+        return new SelectMenuComponent(CustomId, options, Placeholder, MinValues, MaxValues, IsRequired, IsDisabled,
+            Type, Id, ChannelTypes, DefaultValues);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
### Description
Currently when building a select menu when no options are given and sending a message with it, we get the following error:

The server responded with error 50035: Invalid Form Body
Inner Errors:
BASE_TYPE_BAD_LENGTH: Must be between 1 and 25 in length.

It can probably be figured out what exactly is going wrong, but it's not super clear at first.

### Changes
Add some checks and error throwing when building select menu component

